### PR TITLE
Fix commands with non-local-guild user targets

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,7 +55,7 @@ export type CommandOption = {
 
 export interface MahojiUserOption {
 	user: User;
-	member: GuildMember | APIInteractionDataResolvedGuildMember;
+	member?: GuildMember | APIInteractionDataResolvedGuildMember;
 }
 
 type MahojiCommandOption =

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -142,10 +142,13 @@ export function convertAPIOptionsToCommandOptions(
 				parsedOptions[opt.name] = resolvedObjects.roles.get(opt.value as string)!;
 			}
 		} else if (opt.type === ApplicationCommandOptionType.User) {
-			if (resolvedObjects?.users && resolvedObjects.members) {
+			if (resolvedObjects?.users) {
 				parsedOptions[opt.name] = {
 					user: resolvedObjects.users.get(opt.value as string)!,
-					member: resolvedObjects.members.get(opt.value as string)!
+					member:
+						resolvedObjects.members && resolvedObjects.members.has(opt.value as string)
+							? resolvedObjects.members.get(opt.value as string)
+							: null
 				};
 			}
 		} else {


### PR DESCRIPTION
This fixes commands with User parameters.

Currently, if the user does not exist in the local guild/cache, then it won't appear in resolvedObjects.members, nor will the members key itself be set, unless there's 2 user parameters. 

The code makes the member parameter optional; if it's there, we use it, otherwise, it's null.

(The problem is, when members doesn't exist, mahoji doesn't write EITHER the user or member object to the returned parameters)

Win-win.

I have tested this code. 👍 