### PR TITLE
Issue followUp's when interaction is replied already

### DIFF
--- a/src/lib/structures/Mahoji.ts
+++ b/src/lib/structures/Mahoji.ts
@@ -121,6 +121,9 @@ export class MahojiClient {
 					userID: interaction.user.id
 				});
 				if (!response) return;
+				if (interaction.replied) {
+					return interaction.followUp(response);
+				}
 				if (interaction.deferred) {
 					return interaction.editReply(response);
 				}


### PR DESCRIPTION
Automatically issue follow ups if the interaction has already been replied to.

This enables us to handle complicated commands much easier, especially slayer task management for example.

(Currently we have to send a message to channel, but just being able to use interactionReply()  + the command `return` would be much better.

![image](https://github.com/gc/mahoji/assets/10122432/b50b95e1-9a2d-4ce7-aca2-d911f6738c8f)
